### PR TITLE
Swagger integration for release service documentation.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -58,6 +58,20 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
 		</dependency>
+		
+		<!-- Swagger lib for api documentation -->
+		<dependency>
+		    <groupId>com.mangofactory</groupId>
+		    <artifactId>swagger-springmvc</artifactId>
+		    <version>0.9.4</version>
+		</dependency>		
+		
+		<dependency>
+			<groupId>org.webjars</groupId>
+			<artifactId>swagger-ui</artifactId>
+			<version>2.0.24</version>
+		</dependency>
+		
 		<!-- Unit Testing -->
 		<dependency>
 			<groupId>org.hamcrest</groupId>

--- a/api/src/main/java/org/ihtsdo/buildcloud/config/SwaggerConfig.java
+++ b/api/src/main/java/org/ihtsdo/buildcloud/config/SwaggerConfig.java
@@ -1,0 +1,66 @@
+package org.ihtsdo.buildcloud.config;
+
+import com.mangofactory.swagger.plugin.EnableSwagger;
+import com.mangofactory.swagger.paths.RelativeSwaggerPathProvider;
+import com.mangofactory.swagger.plugin.SwaggerSpringMvcPlugin;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import com.mangofactory.swagger.configuration.SpringSwaggerConfig;
+import com.mangofactory.swagger.models.dto.ApiInfo;
+
+/**
+*Class to support configuration of swagger based API documentation
+*/
+@Configuration
+@EnableSwagger
+public class SwaggerConfig {
+	
+	private SpringSwaggerConfig swaggerConfig;
+	private RelativeSwaggerPathProvider pathProvider;
+
+	@Autowired
+	public void setSpringSwaggerConfig(SpringSwaggerConfig swaggerConfig) {
+		
+		this.swaggerConfig = swaggerConfig;
+	}
+   
+
+	@Bean
+	public SwaggerSpringMvcPlugin apiImplementation(){
+		
+		return new SwaggerSpringMvcPlugin(this.swaggerConfig)
+      		 .apiInfo(apiInfo())
+      		 .pathProvider(this.pathProvider);
+
+	}
+   
+	private ApiInfo apiInfo() {
+		
+		return new ApiInfo(
+				"SRS API Docs",
+				"This is a listing of available apis of SNOMED release service. For more technical details visit page @ github.com "
+				+ " - https://github.com/IHTSDO/snomed-release-service ",
+				"https://github.com/IHTSDO/snomed-release-service",
+				"info@ihtsdotools.org",
+				"Apache License, Version 2.0",
+				"http://www.apache.org/licenses/LICENSE-2.0" 
+				);
+	}
+	
+	
+	@Bean
+	public RelativeSwaggerPathProvider setPathProvider(RelativeSwaggerPathProvider pathProvider) {
+		
+		this.pathProvider = pathProvider;
+		this.pathProvider.setApiResourcePrefix("v1");
+		
+		return this.pathProvider;
+		
+	}
+	
+    
+}

--- a/api/src/main/java/org/ihtsdo/buildcloud/controller/BuildController.java
+++ b/api/src/main/java/org/ihtsdo/buildcloud/controller/BuildController.java
@@ -17,17 +17,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.mangofactory.swagger.annotations.ApiIgnore;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Controller
 @RequestMapping("/centers/{releaseCenterKey}/products/{productKey}/builds")
+@Api(value = "Build", position = 1)
 public class BuildController {
 
 	@Autowired
@@ -41,7 +47,9 @@ public class BuildController {
 
 	private static final String[] BUILD_LINKS = {"configuration", "inputfiles", "outputfiles", "logs"};
 
-	@RequestMapping(method = RequestMethod.POST)
+	@RequestMapping( method = RequestMethod.POST )
+	@ApiOperation( value = "Create a build",
+		notes = "Create a build for given product key and release center key" )
 	@ResponseBody
 	public ResponseEntity<Map<String, Object>> createBuild(@PathVariable String releaseCenterKey, @PathVariable String productKey,
 			HttpServletRequest request) throws BusinessServiceException {
@@ -52,7 +60,10 @@ public class BuildController {
 		return new ResponseEntity<>(hypermediaGenerator.getEntityHypermedia(build, currentResource, request, BUILD_LINKS), HttpStatus.CREATED);
 	}
 
-	@RequestMapping
+	@RequestMapping(value = "/", method = RequestMethod.GET )
+	@ApiOperation( value = "Returns a list all builds for a logged in user",
+		notes = "Returns a list all builds visible to the currently logged in user, "
+			+ "so this could potentially span across Release Centres" )
 	@ResponseBody
 	public List<Map<String, Object>> getBuilds(@PathVariable String releaseCenterKey, @PathVariable String productKey,
 			HttpServletRequest request) throws ResourceNotFoundException {
@@ -60,8 +71,10 @@ public class BuildController {
 		return hypermediaGenerator.getEntityCollectionHypermedia(builds, request, BUILD_LINKS);
 	}
 
-	@RequestMapping("/{buildId}")
+	@RequestMapping(value = "/{buildId}", method = RequestMethod.GET )
 	@ResponseBody
+	@ApiOperation( value = "Get a build id",
+	notes = "Returns a single build object for given key" )
 	public Map<String, Object> getBuild(@PathVariable String releaseCenterKey, @PathVariable String productKey,
 			@PathVariable String buildId, HttpServletRequest request) throws ResourceNotFoundException {
 		Build build = buildService.find(releaseCenterKey, productKey, buildId);
@@ -72,8 +85,10 @@ public class BuildController {
 		return hypermediaGenerator.getEntityHypermedia(build, currentResource, request, BUILD_LINKS);
 	}
 
-	@RequestMapping(value = "/{buildId}/configuration", produces = "application/json")
+	@RequestMapping(value = "/{buildId}/configuration", produces = "application/json", method = RequestMethod.GET)
 	@ResponseBody
+	@ApiOperation( value = "Retrieves configuration details",
+	notes = "Retrieves configuration details for given product key, release center key, and build id" )
 	public Map<String, Object> getConfiguration(@PathVariable String releaseCenterKey, @PathVariable String productKey, @PathVariable String buildId,
 			HttpServletRequest request) throws IOException, BusinessServiceException {
 
@@ -81,8 +96,9 @@ public class BuildController {
 		return hypermediaGenerator.getEntityHypermedia(buildConfiguration, true, request);
 	}
 
-	@RequestMapping(value = "/{buildId}/inputfiles")
+	@RequestMapping(value = "/{buildId}/inputfiles", method = RequestMethod.GET)
 	@ResponseBody
+	@ApiIgnore
 	public List<Map<String, Object>> listPackageInputFiles(@PathVariable String releaseCenterKey, @PathVariable String productKey,
 			@PathVariable String buildId, HttpServletRequest request) throws IOException, ResourceNotFoundException {
 
@@ -91,6 +107,7 @@ public class BuildController {
 	}
 
 	@RequestMapping(value = "/{buildId}/inputfiles/{inputFileName:.*}")
+	@ApiIgnore
 	public void getPackageInputFile(@PathVariable String releaseCenterKey, @PathVariable String productKey, @PathVariable String buildId,
 			@PathVariable String inputFileName, HttpServletResponse response) throws IOException, ResourceNotFoundException {
 
@@ -101,6 +118,7 @@ public class BuildController {
 
 	@RequestMapping(value = "/{buildId}/outputfiles")
 	@ResponseBody
+	@ApiIgnore
 	public List<Map<String, Object>> listPackageOutputFiles(@PathVariable String releaseCenterKey, @PathVariable String productKey,
 			@PathVariable String buildId, HttpServletRequest request) throws BusinessServiceException {
 
@@ -109,6 +127,7 @@ public class BuildController {
 	}
 
 	@RequestMapping(value = "/{buildId}/outputfiles/{outputFileName:.*}")
+	@ApiIgnore
 	public void getPackageOutputFile(@PathVariable String releaseCenterKey, @PathVariable String productKey, @PathVariable String buildId,
 			@PathVariable String outputFileName, HttpServletResponse response) throws IOException, ResourceNotFoundException {
 
@@ -119,6 +138,7 @@ public class BuildController {
 
 	@RequestMapping(value = "/{buildId}/trigger", method = RequestMethod.POST)
 	@ResponseBody
+	@ApiIgnore
 	public Map<String, Object> triggerProduct(@PathVariable String releaseCenterKey, @PathVariable String productKey,
 			@PathVariable String buildId, HttpServletRequest request) throws BusinessServiceException {
 		Build build = buildService.triggerBuild(releaseCenterKey, productKey, buildId);
@@ -128,6 +148,7 @@ public class BuildController {
 
 	@RequestMapping(value = "/{buildId}/publish", method = RequestMethod.POST)
 	@ResponseBody
+	@ApiIgnore
 	public void publishBuild(@PathVariable String releaseCenterKey, @PathVariable String productKey,
 			@PathVariable String buildId) throws BusinessServiceException {
 
@@ -138,6 +159,7 @@ public class BuildController {
 
 	@RequestMapping(value = "/{buildId}/logs")
 	@ResponseBody
+	@ApiIgnore
 	public List<Map<String, Object>> getBuildLogs(@PathVariable String releaseCenterKey, @PathVariable String productKey,
 			@PathVariable String buildId, HttpServletRequest request) throws ResourceNotFoundException {
 
@@ -145,6 +167,7 @@ public class BuildController {
 	}
 
 	@RequestMapping(value = "/{buildId}/logs/{logFileName:.*}")
+	@ApiIgnore
 	public void getBuildLog(@PathVariable String releaseCenterKey, @PathVariable String productKey, @PathVariable String buildId,
 			@PathVariable String logFileName, HttpServletResponse response) throws ResourceNotFoundException, IOException {
 

--- a/api/src/main/java/org/ihtsdo/buildcloud/controller/InputFileController.java
+++ b/api/src/main/java/org/ihtsdo/buildcloud/controller/InputFileController.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 @Controller
 @RequestMapping("/centers/{releaseCenterKey}/products/{productKey}")
+@Api(value = "Input Files", position = 4)
 public class InputFileController {
 
 	@Autowired
@@ -37,6 +40,8 @@ public class InputFileController {
 	private static final Logger LOGGER = LoggerFactory.getLogger(InputFileController.class);
 
 	@RequestMapping(value = "/manifest", method = RequestMethod.POST)
+	@ApiOperation( value = "Stores a manifest file",
+		notes = "Stores or replaces a file identified as the manifest for the package specified in the URL" )
 	@ResponseBody
 	public ResponseEntity<Void> uploadManifestFile(@PathVariable final String releaseCenterKey,
 			@PathVariable final String productKey, @RequestParam(value = "file") final MultipartFile file)
@@ -46,7 +51,9 @@ public class InputFileController {
 		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
 
-	@RequestMapping(value = "/manifest")
+	@RequestMapping(value = "/manifest", method = RequestMethod.GET)
+	@ApiOperation( value = "Returns a manifest file name",
+		notes = "Returns a manifest file name for given release center and product" )
 	@ResponseBody
 	public Map<String, Object> getManifest(@PathVariable final String releaseCenterKey, @PathVariable final String productKey,
 			final HttpServletRequest request) throws ResourceNotFoundException {
@@ -60,7 +67,9 @@ public class InputFileController {
 		}
 	}
 
-	@RequestMapping(value = "/manifest/file", produces = "application/xml")
+	@RequestMapping(value = "/manifest/file", produces = "application/xml", method = RequestMethod.GET)
+	@ApiOperation( value = "Returns a specified manifest file",
+		notes = "Returns the content of the manifest file as xml" )
 	public void getManifestFile(@PathVariable final String releaseCenterKey, @PathVariable final String productKey,
 			final HttpServletResponse response) throws ResourceNotFoundException {
 
@@ -78,6 +87,8 @@ public class InputFileController {
 	}
 
 	@RequestMapping(value = "/inputfiles", method = RequestMethod.POST)
+	@ApiOperation( value = "Store or Replace a file",
+		notes = "Stores or replaces a file with its original name against the package specified in the URL" )
 	@ResponseBody
 	public ResponseEntity<Void> uploadInputFileFile(@PathVariable final String releaseCenterKey, @PathVariable final String productKey,
 			@RequestParam(value = "file") final MultipartFile file) throws IOException, ResourceNotFoundException {
@@ -86,7 +97,9 @@ public class InputFileController {
 		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
 
-	@RequestMapping(value = "/inputfiles")
+	@RequestMapping(value = "/inputfiles", method = RequestMethod.GET)
+	@ApiOperation( value = "Returns a list of file names",
+		notes = "Returns a list of file names for the package specified in the URL" )
 	@ResponseBody
 	public List<Map<String, Object>> listInputFiles(@PathVariable final String releaseCenterKey, @PathVariable final String productKey,
 			final HttpServletRequest request) throws ResourceNotFoundException {
@@ -100,7 +113,9 @@ public class InputFileController {
 		return hypermediaGenerator.getEntityCollectionHypermedia(files, request);
 	}
 
-	@RequestMapping(value = "/inputfiles/{inputFileName:.*}")
+	@RequestMapping(value = "/inputfiles/{inputFileName:.*}", method = RequestMethod.GET)
+	@ApiOperation( value = "Returns a specified file",
+		notes = "Returns the content of the specified file." )
 	public void getInputFileFile(@PathVariable final String releaseCenterKey, @PathVariable final String productKey,
 			@PathVariable final String inputFileName,
 			final HttpServletResponse response) throws ResourceNotFoundException {
@@ -120,6 +135,9 @@ public class InputFileController {
 	// Using Regex to match variable name here due to problems with .txt getting truncated
 	// See http://stackoverflow.com/questions/16332092/spring-mvc-pathvariable-with-dot-is-getting-truncated
 	@RequestMapping(value = "/inputfiles/{inputFileNamePattern:.+}", method = RequestMethod.DELETE)
+	@ApiOperation( value = "Returns a specified file",
+		notes = "Deletes the specified file, if found. "
+			+ "Returns HTTP 404 if the file is not found for the package specified in the URL" )
 	public ResponseEntity<Object> deleteInputFile(@PathVariable final String releaseCenterKey, @PathVariable final String productKey,
 			@PathVariable final String inputFileNamePattern) throws IOException, ResourceNotFoundException {
 

--- a/api/src/main/java/org/ihtsdo/buildcloud/controller/LoginController.java
+++ b/api/src/main/java/org/ihtsdo/buildcloud/controller/LoginController.java
@@ -9,18 +9,23 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @Controller
 @RequestMapping("/login")
+@Api(value = "Login", position = 7)
 public class LoginController {
 
 	@Autowired
 	private AuthenticationService authenticationService;
 
 	@RequestMapping(method = RequestMethod.POST)
+	@ApiOperation( value = "Returns an authentication token",
+		notes = "Returns an autentication token which should be set in the headers of future requests " )
 	@ResponseBody
 	public ResponseEntity<Map<String,String>> login(@RequestParam String username, @RequestParam String password) {
 		String authenticationToken = authenticationService.authenticate(username, password);

--- a/api/src/main/java/org/ihtsdo/buildcloud/controller/ProductController.java
+++ b/api/src/main/java/org/ihtsdo/buildcloud/controller/ProductController.java
@@ -13,6 +13,9 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.mangofactory.swagger.annotations.ApiIgnore;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -22,6 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 
 @Controller
 @RequestMapping("/centers/{releaseCenterKey}/products")
+@Api(value = "Product", position = 2)
 public class ProductController {
 
 	@Autowired
@@ -32,7 +36,9 @@ public class ProductController {
 
 	public static final String[] PRODUCT_LINKS = {"manifest", "inputfiles", "builds"};
 
-	@RequestMapping
+	@RequestMapping( method = RequestMethod.GET )
+	@ApiOperation( value = "Returns a list of products",
+	notes = "Returns a list of products for the extension specified in the URL" )
 	@ResponseBody
 	public List<Map<String, Object>> getProducts(@PathVariable String releaseCenterKey, @RequestParam(required = false) boolean includeRemoved,
 			HttpServletRequest request) {
@@ -46,7 +52,8 @@ public class ProductController {
 		return hypermediaGenerator.getEntityCollectionHypermedia(products, request, PRODUCT_LINKS);
 	}
 
-	@RequestMapping("/{productKey}")
+	@RequestMapping( value = "/{productKey}", method = RequestMethod.GET)
+	@ApiOperation( value = "Returns a product", notes = "Returns a single product object" )
 	@ResponseBody
 	public Map<String, Object> getProduct(@PathVariable String releaseCenterKey, @PathVariable String productKey,
 			HttpServletRequest request) throws BusinessServiceException {
@@ -60,6 +67,9 @@ public class ProductController {
 	}
 
 	@RequestMapping(method = RequestMethod.POST, consumes = MediaType.ALL_VALUE)
+	@ApiOperation( value = "Create a product", 
+		notes = "creates a new Product with a name as specified in  the request "
+				+ "and returns the new product object" )
 	public ResponseEntity<Map<String, Object>> createProduct(@PathVariable String releaseCenterKey,
 			@RequestBody(required = false) Map<String, String> json,
 			HttpServletRequest request) throws BusinessServiceException {
@@ -77,6 +87,7 @@ public class ProductController {
 
 	@RequestMapping(value = "/{productKey}", method = RequestMethod.PATCH, consumes = MediaType.ALL_VALUE)
 	@ResponseBody
+	@ApiIgnore
 	public Map<String, Object> updateProduct(@PathVariable String releaseCenterKey, @PathVariable String productKey,
 			@RequestBody(required = false) Map<String, String> json,
 			HttpServletRequest request) throws BusinessServiceException {

--- a/api/src/main/java/org/ihtsdo/buildcloud/controller/ReleaseCenterController.java
+++ b/api/src/main/java/org/ihtsdo/buildcloud/controller/ReleaseCenterController.java
@@ -14,6 +14,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.mangofactory.swagger.annotations.ApiIgnore;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 
 @Controller
 @RequestMapping("/centers")
+@Api(value = "Release Center", position = 3)
 public class ReleaseCenterController {
 
 	@Autowired
@@ -37,7 +41,9 @@ public class ReleaseCenterController {
 
 	private static final String[] RELEASE_CENTER_LINKS = {"products", "published"};
 
-	@RequestMapping
+	@RequestMapping( method = RequestMethod.GET )
+	@ApiOperation( value = "Returns a list all release center for a logged in user",
+		notes = "Returns a list of all release centers visible to the currently logged in user." )
 	@ResponseBody
 	public List<Map<String, Object>> getReleaseCenters(HttpServletRequest request) {
 		List<ReleaseCenter> centers = releaseCenterService.findAll();
@@ -45,6 +51,8 @@ public class ReleaseCenterController {
 	}
 
 	@RequestMapping(value = "", method = RequestMethod.POST, consumes = MediaType.ALL_VALUE)
+	@ApiOperation( value = "Returns a list all release center for a logged in user",
+		notes = " Creates a new Release Center and returns the newly created release center." )
 	public ResponseEntity<Map<String, Object>> createReleaseCenter(@RequestBody(required = false) Map<String, String> json,
 			HttpServletRequest request) throws IOException, EntityAlreadyExistsException {
 
@@ -58,6 +66,9 @@ public class ReleaseCenterController {
 	}
 
 	@RequestMapping(value = "/{releaseCenterBusinessKey}", method = RequestMethod.PUT, consumes = MediaType.ALL_VALUE)
+	@ApiOperation( value = "Updates a release center details",
+		notes = "Allows the name, shortName and the visibility of a release center (soft delete) to be changed.   "
+				+ "Note that the short name is used in the formation of the ‘business key'" )
 	@ResponseBody
 	public Map<String, Object> updateReleaseCenter(@PathVariable String releaseCenterBusinessKey,
 			@RequestBody(required = false) Map<String, String> json,
@@ -72,7 +83,9 @@ public class ReleaseCenterController {
 		return hypermediaGenerator.getEntityHypermedia(center, currentResource, request, RELEASE_CENTER_LINKS);
 	}
 
-	@RequestMapping("/{releaseCenterBusinessKey}")
+	@RequestMapping( value = "/{releaseCenterBusinessKey}", method = RequestMethod.GET)
+	@ApiOperation( value = "Returns a single release center",
+		notes = "Returns a single release center for given releaseCenterBusinessKey" )
 	@ResponseBody
 	public Map<String, Object> getReleaseCenter(@PathVariable String releaseCenterBusinessKey, HttpServletRequest request) throws ResourceNotFoundException {
 
@@ -84,6 +97,7 @@ public class ReleaseCenterController {
 
 	@RequestMapping("/{releaseCenterBusinessKey}/published")
 	@ResponseBody
+	@ApiIgnore
 	public Map<String, Object> getReleaseCenterPublishedPackages(@PathVariable String releaseCenterBusinessKey, HttpServletRequest request) throws ResourceNotFoundException {
 
 		ReleaseCenter center = getReleaseCenterRequired(releaseCenterBusinessKey);
@@ -96,6 +110,7 @@ public class ReleaseCenterController {
 
 	@RequestMapping(value = "/{releaseCenterBusinessKey}/published", method = RequestMethod.POST, consumes = MediaType.ALL_VALUE)
 	@ResponseBody
+	@ApiIgnore
 	public ResponseEntity<Object> publishReleaseCenterPackage(@PathVariable String releaseCenterBusinessKey,
 			@RequestParam(value = "file") final MultipartFile file) throws BusinessServiceException, IOException {
 

--- a/api/src/main/java/org/ihtsdo/buildcloud/controller/RootController.java
+++ b/api/src/main/java/org/ihtsdo/buildcloud/controller/RootController.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import com.mangofactory.swagger.annotations.ApiIgnore;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -13,6 +14,7 @@ import java.util.Map;
 
 @Controller
 @RequestMapping
+@ApiIgnore
 public class RootController {
 
 	@Autowired

--- a/api/src/main/java/org/ihtsdo/buildcloud/controller/UserController.java
+++ b/api/src/main/java/org/ihtsdo/buildcloud/controller/UserController.java
@@ -7,6 +7,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import org.springframework.web.bind.annotation.*;
+
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -15,12 +19,15 @@ import java.util.Map;
 
 @Controller
 @RequestMapping("/user")
+@Api(value = "User", position = 6)
 public class UserController {
 
 	@Autowired
 	private HypermediaGenerator hypermediaGenerator;
 
-	@RequestMapping
+	@RequestMapping( method = RequestMethod.GET)
+	@ApiOperation( value = "Returns the currently logged in user",
+		notes = "Returns the currently logged in user " )
 	@ResponseBody
 	public Map<String, Object> getCurrentUser(HttpServletRequest request) {
 		User authenticatedUser = SecurityHelper.getRequiredUser();

--- a/api/src/main/java/org/ihtsdo/buildcloud/controller/VersionController.java
+++ b/api/src/main/java/org/ihtsdo/buildcloud/controller/VersionController.java
@@ -5,6 +5,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.*;
@@ -13,6 +16,7 @@ import java.util.Map;
 
 @Controller
 @RequestMapping("/version")
+@Api(value = "Version", position = 5)
 public class VersionController {
 
 	public static final String VERSION_FILE_PATH = "/var/opt/snomed-release-service-api/version.txt";
@@ -22,7 +26,9 @@ public class VersionController {
 
 	private String versionString;
 
-	@RequestMapping
+	@RequestMapping( method = RequestMethod.GET )
+	@ApiOperation( value = "Returns version of current deployment",
+		notes = "Returns the software-build version as captured during installation (deployment using ansible)" )
 	@ResponseBody
 	public Map<String, Object> getVersion(HttpServletRequest request) throws IOException {
 		Map<String, String> entity = new HashMap<>();

--- a/api/src/main/resources/servletContext.xml
+++ b/api/src/main/resources/servletContext.xml
@@ -25,4 +25,8 @@
 
 	<bean id="multipartResolver" class="org.springframework.web.multipart.support.StandardServletMultipartResolver"/>
 
+	<mvc:resources mapping="/webjars/**" location="classpath:/META-INF/resources/webjars/"/>
+	<mvc:resources mapping="/api-doc.html" location="/" />
+	<bean class="org.ihtsdo.buildcloud.config.SwaggerConfig" />
+	
 </beans>

--- a/api/src/main/webapp/api-doc.html
+++ b/api/src/main/webapp/api-doc.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Swagger UI</title>
+  <link href='//fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'/>
+  <link href='webjars/swagger-ui/2.0.24/css/reset.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='webjars/swagger-ui/2.0.24/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
+  <link href='webjars/swagger-ui/2.0.24/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
+  <link href='webjars/swagger-ui/2.0.24/css/screen.css' media='print' rel='stylesheet' type='text/css'/>
+  <script type="text/javascript" src="webjars/swagger-ui/2.0.24/lib/shred.bundle.js"></script>
+  <script src='webjars/swagger-ui/2.0.24/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
+  <script src='webjars/swagger-ui/2.0.24/lib/jquery.slideto.min.js' type='text/javascript'></script>
+  <script src='webjars/swagger-ui/2.0.24/lib/jquery.wiggle.min.js' type='text/javascript'></script>
+  <script src='webjars/swagger-ui/2.0.24/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
+  <script src='webjars/swagger-ui/2.0.24/lib/handlebars-1.0.0.js' type='text/javascript'></script>
+  <script src='webjars/swagger-ui/2.0.24/lib/underscore-min.js' type='text/javascript'></script>
+  <script src='webjars/swagger-ui/2.0.24/lib/backbone-min.js' type='text/javascript'></script>
+  <script src='webjars/swagger-ui/2.0.24/lib/swagger.js' type='text/javascript'></script>
+  <script src='webjars/swagger-ui/2.0.24/lib/swagger-client.js' type='text/javascript'></script>
+  <script src='webjars/swagger-ui/2.0.24/swagger-ui.js' type='text/javascript'></script>
+  <script src='webjars/swagger-ui/2.0.24/lib/highlight.7.3.pack.js' type='text/javascript'></script>
+
+  <!-- enabling this will enable oauth2 implicit scope support -->
+  <script src='webjars/swagger-ui/2.0.24/lib/swagger-oauth.js' type='text/javascript'></script>
+
+
+  <!-- enabling this will enable oauth2 implicit scope support -->
+  <script src='webjars/swagger-ui/2.0.24/lib/swagger-oauth.js' type='text/javascript'></script>
+
+  <script type="text/javascript">
+    $(function () {
+      window.swaggerUi = new SwaggerUi({
+      url: window.location.protocol + "//" + window.location.host + "/api/v1/api-docs",
+      dom_id: "swagger-ui-container",
+      supportedSubmitMethods: ['get', 'post', 'put', 'delete'],
+      onComplete: function(swaggerApi, swaggerUi){
+        log("Loaded SwaggerUI");
+
+        $('pre code').each(function(i, e) {
+          hljs.highlightBlock(e)
+        });
+      },
+      onFailure: function(data) {
+        log("Unable to Load SwaggerUI");
+      },
+      docExpansion: "none",
+      sorter : "alpha"
+    });
+
+    $('#input_apiKey').change(function() {
+      var key = $('#input_apiKey')[0].value;
+      log("key: " + key);
+      if(key && key.trim() != "") {
+        log("added key " + key);
+        window.authorizations.add("key", new ApiKeyAuthorization("api_key", key, "query"));
+      }
+    })
+    window.swaggerUi.load();
+  });
+  </script>
+</head>
+
+<body class="swagger-section">
+<div id='header'>
+  <div class="swagger-ui-wrap">
+    <a href="http://ihtsdo.org" ><img alt="IHTSDO's SRS API docs" src="http://www.ihtsdo.org/images/small_logo.png"></a>
+    <form id='api_selector'>
+      <div class='input'><input id="input_baseUrl" name="baseUrl" type="text"/></div>
+      <div class='input'><a id="explore" href="#">Explore</a></div>
+    </form>
+  </div>
+</div>
+
+<div id="message-bar" class="swagger-ui-wrap">&nbsp;</div>
+<div id="swagger-ui-container" class="swagger-ui-wrap"></div>
+</body>
+</html>


### PR DESCRIPTION
This pull has following

1. Swagger integration so that release service apis documentation is available online and can be used by end user
2. Where possible Documentation of various APIs in controllers is being added ( can be viewed on localhost using url http://localhost:8080/api/v1/api-doc.html or replace localhost and port with desired one). 
3. Otherwise an @ApiIgnore is added to method so that this method of controller does not appear in resource listing of API documentation. However one can very well add documentation by removing this annotation and adding relevant annotation and details. Adding this annotation only impact api documentation. API usages remain same as earlier.
4. Number of controller methods were missing specific request methods name. Specific request method name has been added in code so that documentation list apis correctly. Otherwise swagger lists apis with all http methods namely get, post, delete, put ...etc
