### PR TITLE
FRI-311 - Changed S3 storage location

### DIFF
--- a/src/main/java/org/ihtsdo/buildcloud/core/dao/BuildDAOImpl.java
+++ b/src/main/java/org/ihtsdo/buildcloud/core/dao/BuildDAOImpl.java
@@ -14,7 +14,7 @@ import org.apache.activemq.command.ActiveMQTextMessage;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.ihtsdo.buildcloud.core.dao.helper.BuildS3PathHelper;
+import org.ihtsdo.buildcloud.core.dao.helper.S3PathHelper;
 import org.ihtsdo.buildcloud.core.dao.helper.ListHelper;
 import org.ihtsdo.buildcloud.core.dao.io.AsyncPipedStreamBean;
 import org.ihtsdo.buildcloud.core.entity.*;
@@ -73,14 +73,12 @@ public class BuildDAOImpl implements BuildDAO {
 
 	private final ExecutorService executorService;
 
-	private final FileHelper buildFileHelper;
+	private final FileHelper srsFileHelper;
 
 	@Autowired
 	private ObjectMapper objectMapper;
 
 	private final File tempDir;
-
-	private final FileHelper publishedFileHelper;
 
 	private final Rf2FileNameTransformation rf2FileNameTransformation;
 
@@ -93,28 +91,20 @@ public class BuildDAOImpl implements BuildDAO {
 	private ActiveMQTextMessage buildStatusTextMessage;
 
 	@Autowired
-	private BuildS3PathHelper pathHelper;
+	private S3PathHelper pathHelper;
 
 	private String buildBucketName;
 
 	@Autowired
 	private InputFileDAO inputFileDAO;
 
-	@Value("${srs.build.offlineMode}")
-	private Boolean offlineMode;
-
-	@Value("${srs.file-processing.failureMaxRetry}")
-	private Integer fileProcessingFailureMaxRetry;
-
 	@Autowired
-	public BuildDAOImpl(@Value("${srs.build.bucketName}") final String buildBucketName,
-			@Value("${srs.build.published-bucketName}") final String publishedBucketName,
+	public BuildDAOImpl(@Value("${srs.storage.bucketName}") final String storageBucketName,
 			final S3Client s3Client,
 			final S3ClientHelper s3ClientHelper) {
-		this.buildBucketName = buildBucketName;
 		executorService = Executors.newCachedThreadPool();
-		buildFileHelper = new FileHelper(buildBucketName, s3Client, s3ClientHelper);
-		publishedFileHelper = new FileHelper(publishedBucketName, s3Client, s3ClientHelper);
+		buildBucketName = storageBucketName;
+		srsFileHelper = new FileHelper(storageBucketName, s3Client, s3ClientHelper);
 		this.tempDir = Files.createTempDir();
 		rf2FileNameTransformation = new Rf2FileNameTransformation();
 		this.s3Client = s3Client;
@@ -127,7 +117,7 @@ public class BuildDAOImpl implements BuildDAO {
 		if (manifestPath != null) {
 			final String buildManifestDirectoryPath = pathHelper.getBuildManifestDirectoryPath(build);
 			final String manifestFileName = Paths.get(manifestPath).getFileName().toString();
-			buildFileHelper.copyFile(manifestPath, buildManifestDirectoryPath + manifestFileName);
+			srsFileHelper.copyFile(manifestPath, buildManifestDirectoryPath + manifestFileName);
 		}
 	}
 
@@ -312,19 +302,19 @@ public class BuildDAOImpl implements BuildDAO {
 	@Override
 	public InputStream getOutputFileStream(final Build build, final String filePath) {
 		final String outputFilePath = pathHelper.getOutputFilesPath(build) + filePath;
-		return buildFileHelper.getFileStream(outputFilePath);
+		return srsFileHelper.getFileStream(outputFilePath);
 	}
 
 	@Override
 	public List<String> listInputFileNames(final Build build) {
 		final String buildInputFilesPath = pathHelper.getBuildInputFilesPath(build).toString();
-		return buildFileHelper.listFiles(buildInputFilesPath);
+		return srsFileHelper.listFiles(buildInputFilesPath);
 	}
 
 	@Override
 	public InputStream getInputFileStream(final Build build, final String inputFile) {
 		final String path = pathHelper.getBuildInputFilePath(build, inputFile);
-		return buildFileHelper.getFileStream(path);
+		return srsFileHelper.getFileStream(path);
 	}
 
 	@Override
@@ -350,7 +340,7 @@ public class BuildDAOImpl implements BuildDAO {
 	public void copyInputFileToOutputFile(final Build build, final String relativeFilePath) {
 		final String buildInputFilePath = pathHelper.getBuildInputFilePath(build, relativeFilePath);
 		final String buildOutputFilePath = pathHelper.getBuildOutputFilePath(build, relativeFilePath);
-		buildFileHelper.copyFile(buildInputFilePath, buildOutputFilePath);
+		srsFileHelper.copyFile(buildInputFilePath, buildOutputFilePath);
 	}
 
 	@Override
@@ -358,16 +348,16 @@ public class BuildDAOImpl implements BuildDAO {
 		final String sourceFolder = pathHelper.getBuildPath(sourceBuild).toString() + folder;
 		final String destFolder = pathHelper.getBuildPath(destBuild).toString() + folder;
 
-		final List<String> buildInputFilePaths = buildFileHelper.listFiles(sourceFolder);
+		final List<String> buildInputFilePaths = srsFileHelper.listFiles(sourceFolder);
 		for (final String path : buildInputFilePaths) {
-			buildFileHelper.copyFile(sourceFolder + path, destFolder + path);
+			srsFileHelper.copyFile(sourceFolder + path, destFolder + path);
 		}
 	}
 
 	@Override
 	public InputStream getOutputFileInputStream(final Build build, final String name) {
 		final String path = pathHelper.getBuildOutputFilePath(build, name);
-		return buildFileHelper.getFileStream(path);
+		return srsFileHelper.getFileStream(path);
 	}
 
 	@Override
@@ -375,7 +365,7 @@ public class BuildDAOImpl implements BuildDAO {
 		final String filename = file.getName();
 		final String outputFilePath = pathHelper.getBuildOutputFilePath(build, filename);
 		try {
-			return buildFileHelper.putFile(file, outputFilePath, calcMD5);
+			return srsFileHelper.putFile(file, outputFilePath, calcMD5);
 		} catch (NoSuchAlgorithmException | DecoderException e) {
 			throw new IOException("Problem creating checksum while uploading " + filename, e);
 		}
@@ -392,7 +382,7 @@ public class BuildDAOImpl implements BuildDAO {
 		final String filename = file.getName();
 		final String inputFilePath = pathHelper.getBuildInputFilePath(build, filename);
 		try {
-			return buildFileHelper.putFile(file, inputFilePath, calcMD5);
+			return srsFileHelper.putFile(file, inputFilePath, calcMD5);
 		} catch (NoSuchAlgorithmException | DecoderException e) {
 			throw new IOException("Problem creating checksum while uploading " + filename, e);
 		}
@@ -403,7 +393,7 @@ public class BuildDAOImpl implements BuildDAO {
 		final String name = file.getName();
 		final String outputPath = pathHelper.getBuildTransformedFilesPath(build).append(name).toString();
 		try {
-			buildFileHelper.putFile(file, outputPath);
+			srsFileHelper.putFile(file, outputPath);
 		} catch (NoSuchAlgorithmException | DecoderException e) {
 			throw new IOException("Problem creating checksum while uploading transformed file " + name, e);
 		}
@@ -414,7 +404,7 @@ public class BuildDAOImpl implements BuildDAO {
 		String manifestFilePath = getManifestFilePath(build);
 		if (manifestFilePath != null) {
 			LOGGER.info("Opening manifest file found at " + manifestFilePath);
-			return buildFileHelper.getFileStream(manifestFilePath);
+			return srsFileHelper.getFileStream(manifestFilePath);
 		} else {
 			LOGGER.error("Failed to find manifest file for " + build.getId());
 			return null;
@@ -424,37 +414,37 @@ public class BuildDAOImpl implements BuildDAO {
 	@Override
 	public List<String> listTransformedFilePaths(final Build build) {
 		final String transformedFilesPath = pathHelper.getBuildTransformedFilesPath(build).toString();
-		return buildFileHelper.listFiles(transformedFilesPath);
+		return srsFileHelper.listFiles(transformedFilesPath);
 	}
 
 	@Override
 	public List<String> listOutputFilePaths(final Build build) {
 		final String outputFilesPath = pathHelper.getOutputFilesPath(build);
-		return buildFileHelper.listFiles(outputFilesPath);
+		return srsFileHelper.listFiles(outputFilesPath);
 	}
 
 	@Override
 	public List<String> listLogFilePaths(final Build build) {
 		final String logFilesPath = pathHelper.getBuildLogFilesPath(build).toString();
-		return buildFileHelper.listFiles(logFilesPath);
+		return srsFileHelper.listFiles(logFilesPath);
 	}
 
 	@Override
 	public List<String> listBuildLogFilePaths(final Build build) {
 		final String logFilesPath = pathHelper.getBuildLogFilesPath(build).toString();
-		return buildFileHelper.listFiles(logFilesPath);
+		return srsFileHelper.listFiles(logFilesPath);
 	}
 
 	@Override
 	public InputStream getLogFileStream(final Build build, final String logFileName) {
 		final String logFilePath = pathHelper.getBuildLogFilePath(build, logFileName);
-		return buildFileHelper.getFileStream(logFilePath);
+		return srsFileHelper.getFileStream(logFilePath);
 	}
 
 	@Override
 	public InputStream getBuildLogFileStream(final Build build, final String logFileName) {
 		final String logFilePath = pathHelper.getBuildLogFilePath(build, logFileName);
-		return buildFileHelper.getFileStream(logFilePath);
+		return srsFileHelper.getFileStream(logFilePath);
 	}
 
 	@Override
@@ -481,7 +471,7 @@ public class BuildDAOImpl implements BuildDAO {
 	public InputStream getTransformedFileAsInputStream(final Build build,
 													   final String relativeFilePath) {
 		final String transformedFilePath = pathHelper.getTransformedFilePath(build, relativeFilePath);
-		return buildFileHelper.getFileStream(transformedFilePath);
+		return srsFileHelper.getFileStream(transformedFilePath);
 	}
 
 	@Override
@@ -495,7 +485,7 @@ public class BuildDAOImpl implements BuildDAO {
 		}
 		targetFileNameStripped = rf2FileNameTransformation.transformFilename(targetFileName);
 
-		final List<String> filePaths = publishedFileHelper.listFiles(publishedExtractedZipPath);
+		final List<String> filePaths = srsFileHelper.listFiles(publishedExtractedZipPath);
 		for (final String filePath : filePaths) {
 			String filename = FileUtils.getFilenameFromPath(filePath);
 			// use contains rather that startsWith so that we can have candidate release (with x prefix in the filename)
@@ -504,7 +494,7 @@ public class BuildDAOImpl implements BuildDAO {
 				filename = Normalizer.normalize(filename, Normalizer.Form.NFC);
 			}
 			if (filename.contains(targetFileNameStripped)) {
-				return publishedFileHelper.getFileStream(publishedExtractedZipPath + filePath);
+				return srsFileHelper.getFileStream(publishedExtractedZipPath + filePath);
 			}
 		}
 		if (filePaths.isEmpty()) {
@@ -521,7 +511,7 @@ public class BuildDAOImpl implements BuildDAO {
 		// Get the build report as a string we can write to disk/S3 synchronously because it's small
 		String buildReportJSON = build.getBuildReport().toString();
 		try (InputStream is = IOUtils.toInputStream(buildReportJSON, "UTF-8")) {
-			buildFileHelper.putFile(is, buildReportJSON.length(), reportPath);
+			srsFileHelper.putFile(is, buildReportJSON.length(), reportPath);
 		} catch (final IOException e) {
 			LOGGER.error("Unable to persist build report", e);
 		}
@@ -531,9 +521,9 @@ public class BuildDAOImpl implements BuildDAO {
 	public void renameTransformedFile(final Build build, final String sourceFileName, final String targetFileName, boolean deleteOriginal) {
 		final String soureFilePath = pathHelper.getTransformedFilePath(build, sourceFileName);
 		final String targetFilePath = pathHelper.getTransformedFilePath(build, targetFileName);
-		buildFileHelper.copyFile(soureFilePath, targetFilePath);
+		srsFileHelper.copyFile(soureFilePath, targetFilePath);
 		if (deleteOriginal) {
-			buildFileHelper.deleteFile(soureFilePath);
+			srsFileHelper.deleteFile(soureFilePath);
 		}
 	}
 
@@ -709,8 +699,8 @@ public class BuildDAOImpl implements BuildDAO {
 			final String key = objectSummary.getKey();
 			if (key.contains("/status:")) {
 				final String[] keyParts = key.split("/");
-				final String dateString = keyParts[2];
-				final String status = keyParts[3].split(":")[1];
+				final String dateString = keyParts[keyParts.length - 2];
+				final String status = keyParts[keyParts.length - 1].split(":")[1];
 				final Build build = new Build(dateString, product.getBusinessKey(), status);
 				build.setProduct(product);
 				builds.add(build);
@@ -729,9 +719,9 @@ public class BuildDAOImpl implements BuildDAO {
 	private List<Tag> getTags(Build build, final List<String> tagPaths) {
 		for (final String key : tagPaths) {
 			final String[] keyParts = key.split("/");
-			final String dateString = keyParts[2];
+			final String dateString = keyParts[keyParts.length - 2];
 			if (build.getCreationTime().equals(dateString)) {
-				String tagsStr = keyParts[3].split(":")[1];
+				String tagsStr = keyParts[keyParts.length - 1].split(":")[1];
 				String[] tagArr = tagsStr.split(",");
 				List<Tag> tags = new ArrayList<>();
 				for (String tag : tagArr) {
@@ -746,9 +736,9 @@ public class BuildDAOImpl implements BuildDAO {
 	private String getBuildUser(Build build, final List<String> userPaths) {
 		for (final String key : userPaths) {
 			final String[] keyParts = key.split("/");
-			final String dateString = keyParts[2];
+			final String dateString = keyParts[keyParts.length - 2];
 			if (build.getCreationTime().equals(dateString)) {
-				return keyParts[3].split(":")[1];
+				return keyParts[keyParts.length - 1].split(":")[1];
 			}
 		}
 		return null;
@@ -758,8 +748,8 @@ public class BuildDAOImpl implements BuildDAO {
 		List<String> result = new ArrayList<>();
 		for (final String key : visibilityPaths) {
 			final String[] keyParts = key.split("/");
-			final String dateString = keyParts[2];
-			final boolean visibility = Boolean.valueOf(keyParts[3].split(":")[1]);
+			final String dateString = keyParts[keyParts.length - 2];
+			final boolean visibility = Boolean.valueOf(keyParts[keyParts.length - 1].split(":")[1]);
 			if (!visibility) {
 				result.add(dateString);
 			}
@@ -776,7 +766,7 @@ public class BuildDAOImpl implements BuildDAO {
 		final Future<String> future = executorService.submit(new Callable<String>() {
 			@Override
 			public String call() throws Exception {
-				buildFileHelper.putFile(pipedInputStream, buildOutputFilePath);
+				srsFileHelper.putFile(pipedInputStream, buildOutputFilePath);
 				LOGGER.debug("Build outputfile stream ended: {}", buildOutputFilePath);
 				return buildOutputFilePath;
 			}
@@ -813,7 +803,7 @@ public class BuildDAOImpl implements BuildDAO {
 	@Override
 	public String getManifestFilePath(Build build) {
 		final String directoryPath = pathHelper.getBuildManifestDirectoryPath(build);
-		final List<String> files = buildFileHelper.listFiles(directoryPath);
+		final List<String> files = srsFileHelper.listFiles(directoryPath);
 		//The first file in the manifest directory we'll call our manifest
 		if (!files.isEmpty()) {
 			final String manifestFilePath = directoryPath + files.iterator().next();
@@ -826,13 +816,13 @@ public class BuildDAOImpl implements BuildDAO {
 	@Override
 	public InputStream getBuildReportFileStream(Build build) {
 		final String reportFilePath = pathHelper.getReportPath(build);
-		return buildFileHelper.getFileStream(reportFilePath);
+		return srsFileHelper.getFileStream(reportFilePath);
 	}
 
 	@Override
 	public InputStream getBuildInputFilesPrepareReportStream(Build build) {
 		final String reportFilePath = pathHelper.getBuildInputFilePrepareReportPath(build);
-		return buildFileHelper.getFileStream(reportFilePath);
+		return srsFileHelper.getFileStream(reportFilePath);
 	}
 
 	@Override
@@ -856,8 +846,8 @@ public class BuildDAOImpl implements BuildDAO {
 	public void deleteOutputFiles(Build build) {
 		List<String> outputFiles = listOutputFilePaths(build);
 		for (String outputFile : outputFiles) {
-			if (buildFileHelper.exists(outputFile)) {
-				buildFileHelper.deleteFile(outputFile);
+			if (srsFileHelper.exists(outputFile)) {
+				srsFileHelper.deleteFile(outputFile);
 			}
 		}
 	}
@@ -865,7 +855,7 @@ public class BuildDAOImpl implements BuildDAO {
 	@Override
 	public InputStream getBuildInputGatherReportStream(Build build) {
 		String reportFilePath = pathHelper.getBuildInputGatherReportPath(build);
-		return buildFileHelper.getFileStream(reportFilePath);
+		return srsFileHelper.getFileStream(reportFilePath);
 	}
 
 
@@ -908,7 +898,7 @@ public class BuildDAOImpl implements BuildDAO {
 
 	public InputStream getPreConditionCheckReportStream(final Build build) {
 		final String reportFilePath = pathHelper.getBuildPreConditionCheckReportPath(build);
-		return buildFileHelper.getFileStream(reportFilePath);
+		return srsFileHelper.getFileStream(reportFilePath);
 	}
 
 	public List<PreConditionCheckReport> getPreConditionCheckReport(final Build build) throws IOException {
@@ -929,7 +919,7 @@ public class BuildDAOImpl implements BuildDAO {
 	@Override
 	public InputStream getPostConditionCheckReportStream(final Build build) {
 		final String reportFilePath = pathHelper.getPostConditionCheckReportPath(build);
-		return buildFileHelper.getFileStream(reportFilePath);
+		return srsFileHelper.getFileStream(reportFilePath);
 	}
 
 	public List<PostConditionCheckReport> getPostConditionCheckReport(final Build build) throws IOException {
@@ -950,7 +940,7 @@ public class BuildDAOImpl implements BuildDAO {
 	@Override
 	public List<String> listClassificationResultOutputFileNames(Build build) {
 		final String buildInputFilesPath = pathHelper.getClassificationResultOutputFilePath(build).toString();
-		return buildFileHelper.listFiles(buildInputFilesPath);
+		return srsFileHelper.listFiles(buildInputFilesPath);
 	}
 
 	@Override
@@ -958,7 +948,7 @@ public class BuildDAOImpl implements BuildDAO {
 		final String filename = file.getName();
 		final String outputFilePath = pathHelper.getClassificationResultOutputPath(build, filename);
 		try {
-			return buildFileHelper.putFile(file, outputFilePath, false);
+			return srsFileHelper.putFile(file, outputFilePath, false);
 		} catch (NoSuchAlgorithmException | DecoderException e) {
 			throw new IOException("Problem creating checksum while uploading " + filename, e);
 		}
@@ -967,7 +957,7 @@ public class BuildDAOImpl implements BuildDAO {
 	@Override
 	public InputStream getClassificationResultOutputFileStream(Build build, String relativeFilePath) {
 		final String path = pathHelper.getClassificationResultOutputPath(build, relativeFilePath);
-		return buildFileHelper.getFileStream(path);
+		return srsFileHelper.getFileStream(path);
 	}
 
 	@Override
@@ -986,7 +976,7 @@ public class BuildDAOImpl implements BuildDAO {
 	@Override
 	public void putManifestFile(Product product, String buildId, InputStream inputStream) {
 		final String filePath = pathHelper.getBuildManifestDirectoryPath(product, buildId);
-		buildFileHelper.putFile(inputStream, filePath + "manifest.xml");
+		srsFileHelper.putFile(inputStream, filePath + "manifest.xml");
 	}
 
 	@Override
@@ -1004,7 +994,7 @@ public class BuildDAOImpl implements BuildDAO {
 	@Override
 	public List<String> listBuildComparisonReportPaths(Product product) {
 		final String reportPath = pathHelper.getBuildComparisonReportPath(product, null);
-		return buildFileHelper.listFiles(reportPath);
+		return srsFileHelper.listFiles(reportPath);
 	}
 
 	@Override

--- a/src/main/java/org/ihtsdo/buildcloud/core/service/BuildServiceImpl.java
+++ b/src/main/java/org/ihtsdo/buildcloud/core/service/BuildServiceImpl.java
@@ -120,7 +120,7 @@ public class BuildServiceImpl implements BuildService {
 	@Value("${srs.build.offlineMode}")
 	private Boolean offlineMode;
 
-	@Value("${srs.build.bucketName}")
+	@Value("${srs.storage.bucketName}")
 	private String buildBucketName;
 
 	@Value("${srs.jms.queue.prefix}.build-job-status")

--- a/src/main/java/org/ihtsdo/buildcloud/core/service/ExternalMaintainedRefsetsService.java
+++ b/src/main/java/org/ihtsdo/buildcloud/core/service/ExternalMaintainedRefsetsService.java
@@ -2,15 +2,10 @@ package org.ihtsdo.buildcloud.core.service;
 
 import org.ihtsdo.otf.rest.exception.BusinessServiceException;
 
-import java.io.File;
-import java.io.InputStream;
-import java.util.List;
+import java.io.IOException;
 
 public interface ExternalMaintainedRefsetsService {
 
-	void putFile(File file, String target) throws BusinessServiceException;
+    void copyExternallyMaintainedFiles(String releaseCenterKey, String source, String target, boolean isHeaderOnly) throws BusinessServiceException, IOException;
 
-	InputStream getFileStream(String filePath);
-
-	List <String> listFiles(String directoryPath);
 }

--- a/src/main/java/org/ihtsdo/buildcloud/core/service/ExternalMaintainedRefsetsServiceImpl.java
+++ b/src/main/java/org/ihtsdo/buildcloud/core/service/ExternalMaintainedRefsetsServiceImpl.java
@@ -1,6 +1,9 @@
 package org.ihtsdo.buildcloud.core.service;
 
 import org.apache.commons.codec.DecoderException;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.ihtsdo.buildcloud.core.dao.helper.S3PathHelper;
 import org.ihtsdo.otf.dao.s3.S3Client;
 import org.ihtsdo.otf.dao.s3.helper.FileHelper;
 import org.ihtsdo.otf.dao.s3.helper.S3ClientHelper;
@@ -12,9 +15,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
@@ -24,35 +25,66 @@ public class ExternalMaintainedRefsetsServiceImpl implements ExternalMaintainedR
 
     public static final Logger LOGGER = LoggerFactory.getLogger(ExternalMaintainedRefsetsServiceImpl.class);
 
-    private final FileHelper externallyMaintainedFileHelper;
+    private final FileHelper fileHelper;
 
     @Autowired
-    public ExternalMaintainedRefsetsServiceImpl(@Value("${srs.build.externally-maintained-bucketName}") final String externallyMaintainedBucketName,
+    private S3PathHelper s3PathHelper;
+
+    @Autowired
+    public ExternalMaintainedRefsetsServiceImpl(@Value("${srs.storage.bucketName}") final String storageBucketName,
                                                 final S3Client s3Client,
                                                 final S3ClientHelper s3ClientHelper) {
-        externallyMaintainedFileHelper = new FileHelper(externallyMaintainedBucketName, s3Client, s3ClientHelper);
+        fileHelper = new FileHelper(storageBucketName, s3Client, s3ClientHelper);
     }
 
     @Override
-    public void putFile(File file, String target) throws BusinessServiceException {
-        if (externallyMaintainedFileHelper.exists(target)) {
-            externallyMaintainedFileHelper.deleteFile(target);
+    public void copyExternallyMaintainedFiles(String releaseCenterKey, String source, String target, boolean isHeaderOnly) throws BusinessServiceException, IOException {
+        String sourceDirPath = s3PathHelper.getExternallyMaintainedDirectoryPath(releaseCenterKey, source);
+        String targetDirPath = s3PathHelper.getExternallyMaintainedDirectoryPath(releaseCenterKey, target);
+
+        List<String> externalFiles = fileHelper.listFiles(sourceDirPath);
+        for (String externalFile : externalFiles) {
+            // Skip if current object is a directory
+            if (StringUtils.isBlank(externalFile) || externalFile.endsWith(S3PathHelper.SEPARATOR)) {
+                continue;
+            }
+            String sourceFilePath = sourceDirPath + externalFile;
+            String targetFilePath = targetDirPath + externalFile.replaceAll(source, target);
+
+            File tmpFile = File.createTempFile("sct2-file", ".txt");
+            try {
+                InputStream inputStream = fileHelper.getFileStream(sourceFilePath);
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+                     PrintWriter writer = new PrintWriter(new BufferedOutputStream(new FileOutputStream(tmpFile)))) {
+                    String str = reader.readLine();
+                    if (str != null) {
+                        writer.println(str);
+                        if (!isHeaderOnly) {
+                            while ((str = reader.readLine()) != null) {
+                                writer.println(str);
+                            }
+                        }
+                    }
+                } catch (IOException e) {
+                    LOGGER.error("Error copying object {} to temp file. Message: {}", sourceFilePath, e.getMessage());
+                    throw new BusinessServiceException("Error copying object " + sourceFilePath + " to temp file. Message: " + e.getMessage(), e);
+                }
+                putFile(tmpFile, targetFilePath);
+            } finally {
+                FileUtils.forceDelete(tmpFile);
+            }
+        }
+    }
+
+    private void putFile(File file, String targetFilePath) throws BusinessServiceException {
+        if (fileHelper.exists(targetFilePath)) {
+            fileHelper.deleteFile(targetFilePath);
         }
         try {
-            externallyMaintainedFileHelper.putFile(file, target);
+            fileHelper.putFile(file, targetFilePath);
         } catch (NoSuchAlgorithmException | IOException | DecoderException e) {
-            LOGGER.error("Error putting object to target {}. Message: {}", target, e.getMessage());
+            LOGGER.error("Error putting object to target {}. Message: {}", targetFilePath, e.getMessage());
             throw new BusinessServiceException("Error putting object to target. Message: " + e.getMessage(), e);
         }
-    }
-
-    @Override
-    public InputStream getFileStream(String filePath) {
-        return externallyMaintainedFileHelper.getFileStream(filePath);
-    }
-
-    @Override
-    public List <String> listFiles(String directoryPath) {
-        return externallyMaintainedFileHelper.listFiles(directoryPath);
     }
 }

--- a/src/main/java/org/ihtsdo/buildcloud/core/service/build/DailyBuildRF2DeltaExtractor.java
+++ b/src/main/java/org/ihtsdo/buildcloud/core/service/build/DailyBuildRF2DeltaExtractor.java
@@ -14,7 +14,7 @@ import java.util.zip.ZipOutputStream;
 import javax.xml.bind.JAXBException;
 
 import org.ihtsdo.buildcloud.core.dao.BuildDAO;
-import org.ihtsdo.buildcloud.core.dao.helper.BuildS3PathHelper;
+import org.ihtsdo.buildcloud.core.dao.helper.S3PathHelper;
 import org.ihtsdo.buildcloud.core.entity.Build;
 import org.ihtsdo.buildcloud.core.entity.ExtensionConfig;
 import org.ihtsdo.otf.resourcemanager.ResourceManager;
@@ -96,7 +96,7 @@ public class DailyBuildRF2DeltaExtractor {
 			}
 		}
 		String dateStr = DateUtils.now(RF2Constants.DAILY_BUILD_TIME_FORMAT);
-		String targetFilePath = codeSystem + BuildS3PathHelper.SEPARATOR + dateStr + ".zip";
+		String targetFilePath = codeSystem + S3PathHelper.SEPARATOR + dateStr + ".zip";
 		resourceManager.writeResource(targetFilePath, new FileInputStream(zipPackage));
 		LOGGER.info("Daily build package {} is uploaded to S3 {}", zipPackage.getName(), targetFilePath);
 	}

--- a/src/main/java/org/ihtsdo/buildcloud/core/service/inputfile/prepare/InputSourceFileProcessor.java
+++ b/src/main/java/org/ihtsdo/buildcloud/core/service/inputfile/prepare/InputSourceFileProcessor.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.CharEncoding;
-import org.ihtsdo.buildcloud.core.dao.helper.BuildS3PathHelper;
+import org.ihtsdo.buildcloud.core.dao.helper.S3PathHelper;
 import org.ihtsdo.buildcloud.core.entity.Product;
 import org.ihtsdo.buildcloud.core.service.build.RF2Constants;
 import org.ihtsdo.buildcloud.core.service.helper.ManifestXmlFileParser;
@@ -65,7 +65,7 @@ public class InputSourceFileProcessor {
 	private static final String TXT_EXTENSION = ".txt";
 
 	private final FileHelper fileHelper;
-	private final BuildS3PathHelper buildS3PathHelper;
+	private final S3PathHelper s3PathHelper;
 	private final Product product;
 	private File localDir;
 	private File outDir;
@@ -84,10 +84,10 @@ public class InputSourceFileProcessor {
 	private final MultiValueMap<String, String> filesToCopyFromSource;
 	private final MultiValueMap<String, String> refsetWithAdditionalFields;
 
-	public InputSourceFileProcessor(FileHelper fileHelper, BuildS3PathHelper buildS3PathHelper,
+	public InputSourceFileProcessor(FileHelper fileHelper, S3PathHelper s3PathHelper,
 									Product product, boolean copyFilesDefinedInManifest) {
 		this.fileHelper = fileHelper;
-		this.buildS3PathHelper = buildS3PathHelper;
+		this.s3PathHelper = s3PathHelper;
 		this.product = product;
 		this.sourceFilesMap = new HashMap<>();
 		this.refsetFileProcessingConfigs = new HashMap<>();
@@ -217,7 +217,7 @@ public class InputSourceFileProcessor {
 				continue;
 			}
 			//Copy files from S3 to local for processing
-			String s3FilePath = buildS3PathHelper.getBuildSourcesPath(product, buildId).append(sourceFilePath).toString();
+			String s3FilePath = s3PathHelper.getBuildSourcesPath(product, buildId).append(sourceFilePath).toString();
 			InputStream sourceFileStream = null;
 			try {
 				sourceFileStream = fileHelper.getFileStream(s3FilePath);
@@ -730,7 +730,7 @@ public class InputSourceFileProcessor {
 			if (!Normalizer.isNormalized(inputFileName, Form.NFC)) {
 				inputFileName = Normalizer.normalize(inputFileName, Form.NFC);
 			}
-			String filePath =   buildS3PathHelper.getBuildInputFilesPath(product, buildId).append(inputFileName).toString();
+			String filePath =   s3PathHelper.getBuildInputFilesPath(product, buildId).append(inputFileName).toString();
 			fileProcessingReport.add(ReportType.INFO,inputFileName, null, null, "Uploaded to product input files directory");
 			try {
 				fileHelper.putFile(file,filePath);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -83,12 +83,15 @@ snowstorm.reasonerId = org.semanticweb.elk.elk.reasoner.factory
 
 
 # SRS build resource config
-srs.build.externally-maintained-bucketName=local.external.bucket
-srs.build.bucketName = local.build.bucket
-srs.build.published-bucketName = local.published.bucket
+srs.storage.bucketName = local.snomed.releases.bucket
+srs.build.storage.path = local/builds/
+srs.product.manifest.storage.path = local/manifest-files/
+srs.published.releases.storage.path = local/published/
+srs.publish.job.storage.path = local/published/
+srs.externally-maintained.storage.path = local/externally-maintained/
+
 srs.build.versioned-content.bucketName = local.snomed.international.bucket
 srs.build.versioned-content.path = authoring/version-content/
-
 
 # daily build storage for browser import
 dailybuild.storage.readonly = false

--- a/src/test/java/org/ihtsdo/buildcloud/core/service/build/ZipperTest.java
+++ b/src/test/java/org/ihtsdo/buildcloud/core/service/build/ZipperTest.java
@@ -4,7 +4,7 @@ import org.apache.commons.codec.DecoderException;
 import org.apache.commons.io.FilenameUtils;
 import org.ihtsdo.buildcloud.core.dao.BuildDAOImpl;
 import org.ihtsdo.buildcloud.core.dao.ProductDAO;
-import org.ihtsdo.buildcloud.core.dao.helper.BuildS3PathHelper;
+import org.ihtsdo.buildcloud.core.dao.helper.S3PathHelper;
 import org.ihtsdo.buildcloud.core.entity.Build;
 import org.ihtsdo.buildcloud.core.entity.Product;
 import org.ihtsdo.buildcloud.test.AbstractTest;
@@ -39,7 +39,7 @@ public class ZipperTest  extends AbstractTest {
 	private static final Logger LOGGER = LoggerFactory.getLogger(ZipperTest.class);
 
 	@Autowired
-	private BuildS3PathHelper pathHelper;
+	private S3PathHelper pathHelper;
 	
 	@Autowired
 	protected ProductDAO productDAO;
@@ -47,7 +47,7 @@ public class ZipperTest  extends AbstractTest {
 	@Autowired
 	private BuildDAOImpl buildDAO;
 
-	@Value("${srs.build.bucketName}")
+	@Value("${srs.storage.bucketName}")
 	private String buildBucketName;
 	
 	@Autowired 

--- a/src/test/java/org/ihtsdo/buildcloud/core/service/inputfile/prepare/InputSourceFileProcessorTest.java
+++ b/src/test/java/org/ihtsdo/buildcloud/core/service/inputfile/prepare/InputSourceFileProcessorTest.java
@@ -7,7 +7,7 @@ import java.util.Date;
 import java.util.Map;
 
 import org.ihtsdo.buildcloud.TestConfig;
-import org.ihtsdo.buildcloud.core.dao.helper.BuildS3PathHelper;
+import org.ihtsdo.buildcloud.core.dao.helper.S3PathHelper;
 import org.ihtsdo.buildcloud.core.entity.Build;
 import org.ihtsdo.buildcloud.core.entity.Product;
 import org.ihtsdo.buildcloud.core.entity.ReleaseCenter;
@@ -35,9 +35,9 @@ public class InputSourceFileProcessorTest {
 	private static final String EXTERNALLY_MAINTAINED = "externally-maintained";
 	private static final String TERMINOLOGY_SERVER = "terminology-server";
 	@Autowired
-	private BuildS3PathHelper s3PathHelper;
+	private S3PathHelper s3PathHelper;
 
-	@Value("${srs.build.bucketName}")
+	@Value("${srs.storage.bucketName}")
 	private String buildBucketName;
 	
 	@Autowired

--- a/src/test/java/org/ihtsdo/buildcloud/test/TestUtils.java
+++ b/src/test/java/org/ihtsdo/buildcloud/test/TestUtils.java
@@ -1,6 +1,6 @@
 package org.ihtsdo.buildcloud.test;
 
-import org.ihtsdo.buildcloud.core.dao.helper.BuildS3PathHelper;
+import org.ihtsdo.buildcloud.core.dao.helper.S3PathHelper;
 import org.ihtsdo.buildcloud.core.entity.Build;
 import org.ihtsdo.otf.dao.s3.S3Client;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,12 +16,12 @@ import java.io.InputStreamReader;
 public class TestUtils {
 
 	@Autowired
-	private BuildS3PathHelper pathHelper;
+	private S3PathHelper pathHelper;
 
 	@Autowired
 	private S3Client s3Client;
 
-	@Value("${srs.build.bucketName}")
+	@Value("${srs.storage.bucketName}")
 	private String buildBucketName;
 
 	/**


### PR DESCRIPTION
Since we changed the path to builds (added 2 more levels: <env>/builds/) the S3 object key became 2 parts longer. This caused the code that splits S3 key break in BuildDAOImpl (methods findBuilds(), getTags(), getBuildUser() and getInvisibleBuilds())

If similar code that depends on the number of parts in S3 key resides somewhere else and is not covered by tests it may break as well.